### PR TITLE
Fix ax.scatter for atom-project band unfolding

### DIFF
--- a/unfold.py
+++ b/unfold.py
@@ -177,7 +177,7 @@ def EBS_scatter(kpts, cell, spectral_weight,
                 for iatom in range(atomic_weights.shape[0]):
                     ax.scatter(kdist[ik] * x0,
                                spectral_weight[ispin, ik, :, 0] - eref,
-                               s=spectral_weight[ispin, ik, :, 1] * factor * atomic_weights[iatom],
+                               s=spectral_weight[ispin, ik, :, 1] * factor * atomic_weights[iatom, ispin, ik, :],
                                lw=0.0,
                                color=atomic_colors[iatom])
             else:


### PR DESCRIPTION
Hi @QijingZheng!
Thanks for developing a fantastic package!

Just a quick fix for the `ax.scatter` function call when doing atom-projected band unfolding (otherwise you end up an error saying `s` in `scatter` must be an integer or the same size as x or y).

Tested and fixes the issue.

<img width="527" alt="image" src="https://user-images.githubusercontent.com/51478689/112906737-9021a780-90e4-11eb-9176-80f222734094.png">
