### PR TITLE
Update procar.py

### DIFF
--- a/procar.py
+++ b/procar.py
@@ -4,7 +4,10 @@ import os
 import re
 import numpy as np
 from ase.io import read
-from collections import Iterable
+try: # since python 3.10, https://docs.python.org/3/library/collections.abc.html#collections-abstract-base-classes
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 ############################################################
 


### PR DESCRIPTION
For the Python 3.10 compatibility.
The Iterable abstract class was removed from collections in Python 3.10.

- Remove deprecated aliases to [Collections Abstract Base Classes](https://docs.python.org/3/library/collections.abc.html#collections-abstract-base-classes) from the collections module. (Contributed by Victor Stinner in bpo-37324.)