### PR TITLE
Repalce all the List type default values with None

### DIFF
--- a/unfold.py
+++ b/unfold.py
@@ -119,10 +119,10 @@ def make_kpath(kbound, nseg=40):
 
 def EBS_scatter(kpts, cell, spectral_weight,
                 atomic_weights=None,
-                atomic_colors=[],
+                atomic_colors=None,
                 eref=0.0,
                 nseg=None, save='ebs_s.png',
-                kpath_label=[],
+                kpath_label=None,
                 factor=20, figsize=(3.0, 4.0),
                 ylim=(-3, 3), show=True,
                 color='b'):
@@ -142,6 +142,11 @@ def EBS_scatter(kpts, cell, spectral_weight,
     import matplotlib.pyplot as plt
 
     mpl.rcParams['axes.unicode_minus'] = False
+
+    if atomic_weights is None:
+        atomic_weights = []
+    if atomic_colors is None:
+        atomic_colors = []
 
     nspin = spectral_weight.shape[0]
     kpt_c = np.dot(kpts, np.linalg.inv(cell).T)

--- a/unfold.py
+++ b/unfold.py
@@ -214,7 +214,7 @@ def EBS_scatter(kpts, cell, spectral_weight,
 
 def EBS_cmaps(kpts, cell, E0, spectral_function,
               eref=0.0, nseg=None,
-              kpath_label=[],
+              kpath_label=None,
               save='ebs_c.png',
               figsize=(3.0, 4.0),
               ylim=(-3, 3), show=True,
@@ -235,6 +235,9 @@ def EBS_cmaps(kpts, cell, E0, spectral_function,
     import matplotlib.pyplot as plt
 
     mpl.rcParams['axes.unicode_minus'] = False
+
+    if kpath_label is None:
+        kpath_label = []
 
     nspin = spectral_function.shape[0]
     kpt_c = np.dot(kpts, np.linalg.inv(cell).T)

--- a/vaspwfc.py
+++ b/vaspwfc.py
@@ -491,7 +491,7 @@ class vaspwfc(object):
     def wfc_r(self, ispin=1, ikpt=1, iband=1,
               gvec=None, Cg=None, ngrid=None,
               rescale=None,
-              norm=False, kr_phase=False, r0=[0.0, 0.0, 0.0]):
+              norm=False, kr_phase=False, r0=None):
         '''
         Obtain the pseudo-wavefunction of the specified KS states in real space
         by performing FT transform on the reciprocal space planewave
@@ -526,6 +526,9 @@ class vaspwfc(object):
                 "Minium FT grid size: (%d, %d, %d)" % \
                 (self._ngrid[0], self._ngrid[1], self._ngrid[2])
 
+        if r0 is None:
+            r0 = [0.0, 0.0, 0.0]
+        
         # By default, the WAVECAR only stores the periodic part of the Bloch
         # wavefunction. In order to get the full Bloch wavefunction, one need to
         # multiply the periodic part with the phase: exp(i k (r + r0). Below, the


### PR DESCRIPTION
Mutable objects are not recommended as default values. This PR removes all List-type default values and replaces them with None, while defining the actual default values (e.g., empty lists) within the method body.