### PR TITLE
Fix: sph_harm is deprecated in Scipy >= 1.17

### DIFF
--- a/sph_harm.py
+++ b/sph_harm.py
@@ -1,7 +1,14 @@
 #!/usr/bin/env python
 
 import numpy as np
-from scipy.special import sph_harm
+
+try:
+    from scipy.special import sph_harm_y
+
+    def _sph_harm(m, n, azimuth, polar):
+        return sph_harm_y(n, m, polar, azimuth)
+except ImportError:
+    from scipy.special import sph_harm as _sph_harm
 
 
 def cart2sph(xyz, epsilon=1E-10):
@@ -53,7 +60,7 @@ def sph_c(xyz, l, m=None):
 
     r, phi, theta = cart2sph(xyz)
     N = xyz.shape[0]
-    ylm = [sph_harm(M, l, phi, theta) for M in range(-l, l+1)]
+    ylm = [_sph_harm(M, l, phi, theta) for M in range(-l, l+1)]
 
     if m is None:
         return np.array(ylm, dtype=complex).T


### PR DESCRIPTION
This pull request updates the way spherical harmonics are computed to improve compatibility with different versions of SciPy. The main change is to use `sph_harm_y` if available, otherwise falling back to the original `sph_harm` function. The rest of the code is updated to use this new internal wrapper function.

Compatibility improvements:

* Added a compatibility layer that tries to import `sph_harm_y` from `scipy.special` and defines an internal `_sph_harm` function to call it; if unavailable, falls back to the original `sph_harm` function. This ensures that the code works with both new and old versions of SciPy. (`sph_harm.py`)
* Updated all calls in the code (specifically in `sph_c`) to use the new `_sph_harm` wrapper instead of directly calling `sph_harm`. (`sph_harm.py`)